### PR TITLE
feat: head block endpoint

### DIFF
--- a/src/block/index.js
+++ b/src/block/index.js
@@ -1,0 +1,3 @@
+export { blockPost } from './post.js'
+export { blockGet } from './get.js'
+export { blockHead } from './head.js'

--- a/src/block/utils.js
+++ b/src/block/utils.js
@@ -1,0 +1,49 @@
+import { CID } from 'multiformats/cid'
+import { base58btc } from 'multiformats/bases/base58'
+
+import { BaseNotFoundError } from '../errors.js'
+
+/**
+ * Get multihash from CID if provided value is a cid.
+ *
+ * @param {string} value
+ */
+export function getMultihashFromCidValue (value) {
+  let multihash
+
+  try {
+    const cid = CID.parse(value)
+    multihash = base58btc.encode(cid.multihash.bytes)
+  } catch (err) {
+    return
+  }
+
+  return multihash
+}
+
+/**
+ * Encode given multihash into base58btc.
+ *
+ * @param {string} multihash
+ * @param {import('ipfs-core-utils/multibases').Multibases} bases
+ */
+export async function toBase58btc (multihash, bases) {
+  let base
+  try {
+    const multibasePrefix = multihash[0]
+    base = await bases.getBase(multibasePrefix)
+  } catch (err) {
+    throw new BaseNotFoundError()
+  }
+
+  let encodedMultihash = multihash
+  // We use base58btc encoding internally for caching
+  if (base.name !== base58btc.name) {
+    const bytes = base.decoder.decode(multihash)
+
+    // Base 58 encoded for R2 key
+    encodedMultihash = base58btc.encode(bytes)
+  }
+
+  return encodedMultihash
+}

--- a/src/index.js
+++ b/src/index.js
@@ -7,8 +7,7 @@ import { envAll } from './env.js'
 import { errorHandler } from './error-handler.js'
 import { addCorsHeaders, withCorsHeaders } from './cors.js'
 import { versionGet } from './version.js'
-import { blockPost } from './block/post.js'
-import { blockGet } from './block/get.js'
+import { blockPost, blockGet, blockHead } from './block/index.js'
 
 const router = Router()
 
@@ -22,6 +21,7 @@ router
   .get('/version', auth['🤲'](versionGet))
   .post('/', auth['🔒'](blockPost))
   .get('/:multihash', auth['🔒'](blockGet))
+  .head('/:multihash', auth['🔒'](blockHead))
 
 /**
  * @param {Error} error


### PR DESCRIPTION
This PR adds `HEAD /:multihash`

Common function utils to get the the R2 key were moved to utils function. Head handler uses [r2.head](https://github.com/cloudflare/workers-types/blob/master/index.d.ts#L1009) operation and returns 200 if exists (with content length header). If not existent, returns 404

Closes #7 