### PR TITLE
chore: workflow release only run on main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,6 +51,7 @@ jobs:
           apiToken: ${{secrets.CF_API_TOKEN }}
           environment: 'staging'
   release:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changelog.outputs.releases_created
     name: Release
     runs-on: ubuntu-latest
     needs: test


### PR DESCRIPTION
It was running to create a PR anytime. Should only do it on main commit